### PR TITLE
Detecting hooks of modern EdXposed framework for android 8,9,Q

### DIFF
--- a/distribution/const_general.c
+++ b/distribution/const_general.c
@@ -55,6 +55,13 @@ const char * const MG_EXPOSED_FILES[] = {
         "/magisk/xposed/system/lib/libart-compiler.so",
         "/system/bin/app_process32_orig",
         "/system/bin/app_process64_orig",
+        "/system/lib/libmemtrack_real.so",
+        "/system/lib64/libmemtrack_real.so",
+        "/system/lib/libriru_edxp.so",
+        "/system/lib64/libriru_edxp.so",
+        "/system/lib/libwhale.edxp.so",
+        "/system/lib64/libwhale.edxp.so",
+        "/system/framework/edxp.jar",
         0
 };
 

--- a/distribution/meat_grinder.c
+++ b/distribution/meat_grinder.c
@@ -287,10 +287,12 @@ bool isFoundHooks() {
     memset(line, 0, line_size);
     const char *substrate = "com.saurik.substrate";
     const char *xposed = "XposedBridge.jar";
+    const char *edxposed = "edxp.jar";
     while (fgets(line, line_size, fp) != NULL) {
         const size_t real_line_size = strlen(line);
         if ((real_line_size >= strlen(substrate) && strstr(line, substrate) != NULL) ||
-            (real_line_size >= strlen(xposed) && strstr(line, xposed) != NULL)) {
+            (real_line_size >= strlen(xposed) && strstr(line, xposed) != NULL) ||
+            (real_line_size >= strlen(edxposed) && strstr(line, edxposed) != NULL)) {
             GR_LOGI("found in [%s]: [%s]", maps_file_name, line);
             result = true;
             break;


### PR DESCRIPTION
Добрый вечер. Спасибо за ваше отличное приложение для детекта рута. Пользуюсь им с удовольствием. Решил предложить небольшую правку:

В текущей реализации проверки на хуки в коде есть место где мы проверяем файлы замапившие в память запущенного процесса приложения данные и проверяем нет ли среди них XposedBridge.jar. Проблема в том что этот джарник относится к старому xposed фреймоворку, который устанавливался напрямую в /system до ужесточения политик SELinux в android 8. Поэтому приложение не обнаруживает хуки даже если они есть. Современный вариант xposed фрейморка - EdXposed ставится из репозитория magisk модулей и главный джарник с его классами называется edxp.jar. Я добавил проверку на его название а также внёс в список подозрительных файлов файлы которые вносит в систему Riru core без которого EdXposed работать не может. 

При включённом magisk-hide приложение всё равно даже из нейтив кода не сможет обнаружить бинарник su и другие признаки рута, но с этой правкой хуки xposed фреймворка обнаруживаются даже если пользователь врубил magisk-hide.

Буду признателен если это войдёт в мастер ветку и в сборку в гуглплее